### PR TITLE
add support for msgpack 2.0 binary type

### DIFF
--- a/mprpc/client.pyx
+++ b/mprpc/client.pyx
@@ -40,7 +40,7 @@ cdef class RPCClient:
     cdef _unpacker
 
     def __init__(self, host, port, timeout=None, lazy=False,
-                 pack_encoding='utf-8', unpack_encoding='utf-8'):
+                 pack_encoding='utf-8', unpack_encoding='utf-8', use_bin_type=False):
         self._host = host
         self._port = port
         self._timeout = timeout
@@ -48,7 +48,7 @@ cdef class RPCClient:
         self._msg_id = 0
         self._socket = None
 
-        self._packer = msgpack.Packer(encoding=pack_encoding)
+        self._packer = msgpack.Packer(encoding=pack_encoding, use_bin_type=use_bin_type)
         self._unpacker = msgpack.Unpacker(encoding=unpack_encoding, use_list=False)
 
         if not lazy:

--- a/mprpc/server.pyx
+++ b/mprpc/server.pyx
@@ -38,8 +38,9 @@ cdef class RPCServer:
     def __init__(self, *args, **kwargs):
         pack_encoding = kwargs.pop('pack_encoding', 'utf-8')
         unpack_encoding = kwargs.pop('unpack_encoding', 'utf-8')
+        use_bin_type = kwargs.pop('use_bin_type', False)
 
-        self._packer = msgpack.Packer(encoding=pack_encoding)
+        self._packer = msgpack.Packer(encoding=pack_encoding, use_bin_type=use_bin_type)
         self._unpacker = msgpack.Unpacker(encoding=unpack_encoding,
                                           use_list=False)
 


### PR DESCRIPTION
This PR adds the possibility to send binary data (as defined in msgpack 2.0). 

Without it binary content is send as string which fails during unpack because the client tries to decode it (using utf-8).

As client and server are provided it might be even better to enable this per default.