### PR TITLE
check type at client and server side to make protocol more robust

### DIFF
--- a/mprpc/client.pyx
+++ b/mprpc/client.pyx
@@ -134,6 +134,10 @@ cdef class RPCClient:
             except StopIteration:
                 continue
 
+        if type(response) != tuple:
+            logging.debug('Protocol error, received unexpected data: {}'.format(data))
+            raise RPCProtocolError('Invalid protocol')
+
         return self._parse_response(response)
 
     cdef bytes _create_request(self, method, tuple args):

--- a/mprpc/server.pyx
+++ b/mprpc/server.pyx
@@ -76,6 +76,14 @@ cdef class RPCServer:
             except StopIteration:
                 continue
 
+            if type(req) != tuple:
+                self._send_error("Invalid protocol", -1, conn)
+                # reset unpacker as it might have garbage data
+                unpacker = msgpack.Unpacker(encoding=self._unpack_encoding,
+                                    **self._unpack_params)
+                continue
+
+
             (msg_id, method, args) = self._parse_request(req)
 
             try:


### PR DESCRIPTION
without that cython produces some unreadable errors (cast to tuple fails)