### PR TITLE
Fix defaults for msgpack-python with respect to blobs

### DIFF
--- a/mprpc/client.pyx
+++ b/mprpc/client.pyx
@@ -61,7 +61,7 @@ cdef class RPCClient:
         self._socket = None
         self._tcp_no_delay = tcp_no_delay
         self._keep_alive = keep_alive
-        self._pack_params = pack_params or dict()
+        self._pack_params = pack_params or dict(use_bin_type=True)
         self._unpack_encoding = unpack_encoding
         self._unpack_params = unpack_params or dict(use_list=False)
 

--- a/mprpc/server.pyx
+++ b/mprpc/server.pyx
@@ -44,7 +44,7 @@ cdef class RPCServer:
 
     def __init__(self, *args, **kwargs):
         pack_encoding = kwargs.pop('pack_encoding', 'utf-8')
-        pack_params = kwargs.pop('pack_params', dict())
+        pack_params = kwargs.pop('pack_params', dict(use_bin_type=True))
 
         self._unpack_encoding = kwargs.pop('unpack_encoding', 'utf-8')
         self._unpack_params = kwargs.pop('unpack_params', dict(use_list=False))


### PR DESCRIPTION
msgpack-python defaults to using binary strings, unless an encoding is
specified. In that case, `use_bin_type=True` needs to also be specified
to allow blobs to be serialized as well as strings.

mprpc specifies an encoding, but not `use_bin_type`, which this commit
rectifies. The default setting now allows Unicode strings well as
arbitrary blobs.