### PR TITLE
Fix Py2k method name type

### DIFF
--- a/mprpc/client.pyx
+++ b/mprpc/client.pyx
@@ -3,6 +3,7 @@
 
 import msgpack
 import time
+import sys
 from gevent import socket
 from gsocketpool.connection import Connection
 
@@ -120,12 +121,16 @@ cdef class RPCClient:
         else:
             return False
 
-    def call(self, str method, *args):
+    def call(self, str method_str, *args):
         """Calls a RPC method.
 
         :param str method: Method name.
         :param args: Method arguments.
         """
+        if sys.version_info.major >= 3:
+            method = method_str
+        else:
+            method = unicode(method_str)
 
         cdef bytes req = self._create_request(method, args)
 


### PR DESCRIPTION
The fix introduced in 227231f3 introduced another bug: By enabling
binary strings, Python 2 would serialize the method name as a binary
string, not UTF-8 as according to the standard.
An obvious way to make this fail is by running the server with Python 3
and the client with Python 2.

This conditionally converts strings to UTF-8 when using Python 2.

Signed-off-by: Martin Braun <martin.braun@ettus.com>